### PR TITLE
Add unit "per micrometre" to barril

### DIFF
--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -401,6 +401,16 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         f_unit_to_base,
         default_category=None,
     )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1000000, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1000000, 1.0, 0.0)
+    db.AddUnit(
+        "per length",
+        "per micrometre",
+        "1/um",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 1, 86400, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 1, 86400, 0.0)
     db.AddUnit(


### PR DESCRIPTION
* Add Unit option "per micrometre" to Category "per length" and its conversion to base unit "per metre"

PORE-1464