### PR TITLE
Now raised QuantityValidationError from Quantity.CheckValue

### DIFF
--- a/src/barril/units/_quantity.py
+++ b/src/barril/units/_quantity.py
@@ -8,6 +8,7 @@ import six
 from six.moves import range, zip  # @UnresolvedImport
 
 from barril._foundation.odict import odict
+from barril.units.exceptions import QuantityValidationError
 from barril.units.unit_database import UnitsError
 from ._unit_constants import UNKNOWN_UNIT
 from .unit_database import UnitDatabase
@@ -718,8 +719,8 @@ class _Quantity(Quantity):
 
     def _RaiseValueError(self, value, operator, limit_value, use_literals):
         """
-        Raises a ValueError exception with a formatted message about the comparison of the value
-        with it's limit.
+        Raises a QuantityValidationError exception with a formatted message about the comparison of the value
+        with it's limit and it's values as attributes.
 
         :param float value:
             Value with boundary error.
@@ -733,15 +734,19 @@ class _Quantity(Quantity):
         :param Boolean use_literals:
             If literals are to be used in the error message.
         """
-        invalid_value_message = "Invalid value for %s: %g. Must be %s %r."
-        raise ValueError(
-            invalid_value_message
-            % (
-                self._category_info.caption,
-                value,
-                self._GetComparison(operator, use_literals),
-                limit_value,
-            )
+        invalid_value_message = "Invalid value for %s: %g. Must be %s %r." % (
+            self._category_info.caption,
+            value,
+            self._GetComparison(operator, use_literals),
+            limit_value,
+        )
+
+        raise QuantityValidationError(
+            invalid_value_message,
+            self._category_info.caption,
+            value,
+            self._GetComparison(operator, use_literals),
+            limit_value
         )
 
     def CheckValue(self, value, use_literals=False):
@@ -751,7 +756,7 @@ class _Quantity(Quantity):
         :param float value:
             The value to be checked.
 
-        :raises ValueError:
+        :raises QuantityValidationError:
             if the value is not valid for this quantity.
         """
         if self._is_derived:  # It's not possible to check value for a derived category.

--- a/src/barril/units/_tests/test_unit_database.py
+++ b/src/barril/units/_tests/test_unit_database.py
@@ -20,6 +20,7 @@ from barril.units import (
     Quantity,
     UnitsError,
 )
+from barril.units.exceptions import QuantityValidationError
 from barril.units.unit_database import UnitDatabase
 
 
@@ -214,20 +215,24 @@ def testCategory(unit_database_custom_conversion):
     quantity = ObtainQuantity("m", "my length")
     formatted_value = FormatFloat("%g", -6e-010)
     with pytest.raises(
-        ValueError,
+        QuantityValidationError,
         match="Invalid value for My Length: %s. Must be > %s."
         % (formatted_value, formatted_value),
-    ):
+    ) as exc_info:
         quantity.CheckValue(-6e-10)
+    e = exc_info.value
+    assert hasattr(e, 'caption') is True
 
     quantity.CheckValue(0)  # without specifying unit
     mm_quantity = ObtainQuantity("mm", "my length")
     mm_quantity.CheckValue(2e5)
 
     with pytest.raises(
-        ValueError, match="Invalid value for My Length: 200000. Must be <= 200000.0."
-    ):
+        QuantityValidationError, match="Invalid value for My Length: 200000. Must be <= 200000.0."
+    ) as exc_info:
         mm_quantity.CheckValue(2e8 + 1)
+    e = exc_info.value
+    assert hasattr(e, 'message') is True
 
     # Check the unit info using a category instead a quantity_type
     with pytest.raises(InvalidQuantityTypeError):

--- a/src/barril/units/exceptions.py
+++ b/src/barril/units/exceptions.py
@@ -1,0 +1,24 @@
+
+
+class QuantityValidationError(ValueError):
+    def __init__(self, message, caption, value, operator, limit_value):
+        """
+            QuantityValidationError inherits from ValueError
+            with helpers attributes (message, caption, value, operator, limit_value)
+        :param message:
+            the full formatted message
+        :param caption:
+            caption of the category info
+        :param value:
+            value validated
+        :param operator:
+            operator (literal or not)
+        :param limit_value:
+            limit value
+        """
+        super(QuantityValidationError, self).__init__(message)
+        self.message = message
+        self.caption = caption
+        self.value = value
+        self.operator = operator
+        self.limit_value = limit_value


### PR DESCRIPTION
The old raised Exception do not have the required attributes to properly translate the message

* Raise instanced QuantityValidationError instead of just ValueError with formatted message
* Add exception module with QuantityValidationError Exception
* Update tests with QuantityValidationError instead ValueError
* Check if exception info has expected attributes

SIMBR-1699