### PR TITLE
Fix ValueGenerator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+1.7.1 (unreleased)
+------------------
+
+* Fixed bug in ``/`` and ``-`` operators for ``FixedArray``.
 
 1.7.0 (2019-06-18)
 ------------------

--- a/src/barril/units/_tests/test_fixedarray.py
+++ b/src/barril/units/_tests/test_fixedarray.py
@@ -4,7 +4,6 @@ from pytest import approx
 from barril._foundation.odict import odict
 from barril import units
 from barril.units import InvalidUnitError, ObtainQuantity, Quantity
-import operator
 
 
 def testFormatting(unit_database_start_units):
@@ -185,28 +184,3 @@ def testFixedArrayIndexAsScalar():
     assert fixed_array.IndexAsScalar(0).GetCategory() == "length of path"
     assert fixed_array.IndexAsScalar(0) == Scalar("length of path", 1, "m")
     assert fixed_array.IndexAsScalar(1) == Scalar("length of path", 2, "m")
-
-
-@pytest.mark.parametrize(
-    "left, op, right, expected",
-    [
-        ([100, 80, 50], operator.truediv, 2, [50, 40, 25]),
-        ([100, 80, 50], operator.sub, 2, [98, 78, 48]),
-        (2, operator.sub, [100, 80, 50], [-98, -78, -48]),
-        (2, operator.add, [100, 80, 50], [102, 82, 52]),
-        ([100, 80, 50], operator.add, 2, [102, 82, 52]),
-        (2, operator.mul, [100, 80, 50], [200, 160, 100]),
-        ([100, 80, 50], operator.mul, 2, [200, 160, 100]),
-    ],
-)
-def testFixedArrayScalarOperations(left, op, right, expected):
-    def Make3Array(values):
-        return units.FixedArray(3, "length", values, "m")
-
-    if isinstance(left, list):
-        left = Make3Array(left)
-    if isinstance(right, list):
-        right = Make3Array(right)
-
-    result = op(left, right)
-    assert result == Make3Array(expected)

--- a/src/barril/units/_tests/test_fixedarray.py
+++ b/src/barril/units/_tests/test_fixedarray.py
@@ -184,3 +184,12 @@ def testFixedArrayIndexAsScalar():
     assert fixed_array.IndexAsScalar(0).GetCategory() == "length of path"
     assert fixed_array.IndexAsScalar(0) == Scalar("length of path", 1, "m")
     assert fixed_array.IndexAsScalar(1) == Scalar("length of path", 2, "m")
+
+
+def testFixedArrayScalarOperations():
+    original = units.FixedArray(3, "length", [100, 80, 50], "m")
+    expected_division = units.FixedArray(3, "length", [50, 40, 25], "m")
+    expected_subtraction = units.FixedArray(3, "length", [-98, -78, -48], "m")
+
+    assert original / 2 == expected_division
+    assert 2 - original == expected_subtraction

--- a/src/barril/units/_tests/test_operations.py
+++ b/src/barril/units/_tests/test_operations.py
@@ -2,6 +2,7 @@ import operator
 
 import pytest
 
+from barril import units
 from barril.units import ObtainQuantity
 from barril.units.unit_database import UnitDatabase
 
@@ -87,3 +88,36 @@ def testOperation():
 
     with pytest.raises(TypeError):
         operator.mul(q, "s")
+
+
+def MakeArray(values):
+    """Creates a standard array used by testScalarOperations"""
+    return units.Array("length", values, "m")
+
+
+def MakeFixedArray(values):
+    """Creates a fixed array with 3 dimensions used by testScalarOperations"""
+    return units.FixedArray(3, "length", values, "m")
+
+
+@pytest.mark.parametrize(
+    "left, op, right, expected",
+    [
+        ([100, 80, 50], operator.truediv, 2, [50, 40, 25]),
+        ([100, 80, 50], operator.sub, 2, [98, 78, 48]),
+        (2, operator.sub, [100, 80, 50], [-98, -78, -48]),
+        (2, operator.add, [100, 80, 50], [102, 82, 52]),
+        ([100, 80, 50], operator.add, 2, [102, 82, 52]),
+        (2, operator.mul, [100, 80, 50], [200, 160, 100]),
+        ([100, 80, 50], operator.mul, 2, [200, 160, 100]),
+    ],
+)
+@pytest.mark.parametrize("array_maker", [MakeArray, MakeFixedArray])
+def testScalarOperations(left, op, right, expected, array_maker):
+    if isinstance(left, list):
+        left = array_maker(left)
+    if isinstance(right, list):
+        right = array_maker(right)
+
+    result = op(left, right)
+    assert result == array_maker(expected)

--- a/src/barril/units/_value_generator.py
+++ b/src/barril/units/_value_generator.py
@@ -56,12 +56,12 @@ class _ValueGenerator:
         elif self.iterate_1st and not self.iterate_2nd:
             static_value = self.p2
             for v in self.p1:
-                yield static_value, v
+                yield v, static_value
 
         elif not self.iterate_1st and self.iterate_2nd:
             static_value = self.p1
             for v in self.p2:
-                yield v, static_value
+                yield static_value, v
 
         elif not self.iterate_1st and not self.iterate_2nd:
             yield self.p1, self.p2


### PR DESCRIPTION
ValueGenerator was generating switched tuples for division and subtraction.

Example: `FixedArray(3, 'lenght', [10, 10, 10], 'm') / 2` would result in `[0.2, 0.2, 0.2]` intead of the expected `[5, 5, 5]`.
And `FixedArray(3, 'lenght', [0, 0, 0], 'm') / 2` would raise division by zero.