### PR TITLE
Remove legacy representation and add support for backward compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ UNRELEASED
 * ``_foundation`` has been renamed to ``_util``, and a lot of functions which were not being
   used anymore have been removed.
 * Add new unit category mass temperature per mol (``kg.K/mol``).
+* Some units have been renamed as they were deemed out-of-place in the oil industry to something more usual (for example, ``1000ft3/d`` became ``Mcf/d``).
+  The old representation of those units is still supported, but they will be automatically translated during ``Quantity`` creation, so this change should not affect users much.
 
 1.7.1 (2019-10-03)
 ------------------

--- a/src/barril/curve/curve.py
+++ b/src/barril/curve/curve.py
@@ -80,7 +80,7 @@ class Curve:
         """
         :rtype: int
         :returns:
-            The lenght of the curve
+            The length of the curve
         """
         return len(self._image.GetValues())
 

--- a/src/barril/units/_scalar.py
+++ b/src/barril/units/_scalar.py
@@ -8,8 +8,8 @@ from barril._util.types_ import IsNumber
 from oop_ext.interface._interface import ImplementsInterface
 
 from ._abstractvaluewithquantity import AbstractValueWithQuantityObject
-from .interfaces import IQuantity, IScalar
 from ._quantity import ObtainQuantity, Quantity
+from .interfaces import IQuantity, IScalar
 from .unit_database import UnitDatabase
 
 __all__ = ["Scalar"]

--- a/src/barril/units/_tests/test_legacy_unit.py
+++ b/src/barril/units/_tests/test_legacy_unit.py
@@ -1,0 +1,108 @@
+from barril.units import Scalar
+from pytest import approx, raises
+
+
+def testConvertLegacyUnit():
+    from barril.units.unit_database import _LEGACY_TO_CURRENT
+
+    # test creating scalar using legacy representation and default category
+    q = Scalar(1.0, "1000ft3/d")
+    assert q.GetUnit() == "Mcf/d"
+
+    # test creating scalar using legacy representation
+    q = Scalar(category="volume flow rate", value=1.0, unit="1000ft3/d")
+    assert q.GetUnit() == "Mcf/d"
+
+    # test getting value using legacy representation
+    assert approx(q.GetValue("M(ft3)/d")) == q.GetValue("MMcf/d")
+
+    q = Scalar(category="volume flow rate", value=1.0, unit="M(ft3)/d")
+    assert q.GetUnit() == "MMcf/d"
+    assert approx(q.GetValue("M(ft3)/d")) == q.GetValue("MMcf/d")
+    assert q.GetUnitName() == "million cubic feet per day"
+
+    # Test all possible legacy formats
+    for legacy, current in _LEGACY_TO_CURRENT:
+        assert Scalar(1.0, legacy).GetUnit() == current
+
+
+def testCreateScalarUnitsError():
+    from barril.units.unit_database import UnitsError
+
+    with raises(UnitsError, match="Unable to get default category for: foo/d"):
+        _ = Scalar(1.0, "foo/d")
+
+
+def testGetValueInvalidUnitError():
+    from barril.units.unit_database import InvalidUnitError
+
+    with raises(
+        InvalidUnitError,
+        match="Invalid unit for quantity_type volume flow rate: 1000ft3/foo",
+    ):
+        q = Scalar(1.0, "1000ft3/d")
+        q.GetValue("1000ft3/foo")
+
+
+def testFixUnitIfIsLegacyExcept():
+    from barril.units.unit_database import FixUnitIfIsLegacy
+
+    class SomeNonExpectedObject:
+        pass
+
+    unknown = SomeNonExpectedObject()
+    is_legacy, unit = FixUnitIfIsLegacy(unknown)
+    assert is_legacy == False
+    assert unit is unknown
+
+
+def testUnitDatabaseConvert(unit_database_posc):
+    import numpy as np
+
+    # Test against float
+    converted = unit_database_posc.Convert("volume flow rate", "1000ft3/d", "m3/d", 1.0)
+    assert approx(converted) == 28.31685
+
+    converted = unit_database_posc.Convert("volume flow rate", "M(ft3)/d", "m3/d", 1.0)
+    assert approx(converted) == 28316.85
+
+    # Test against numpy arrays
+    converted = unit_database_posc.Convert(
+        "volume flow rate", "1000ft3/d", "m3/d", np.ones(2)
+    )
+    assert approx(converted) == 28.31685
+    converted = unit_database_posc.Convert(
+        "volume flow rate", "M(ft3)/d", "m3/d", np.ones(2)
+    )
+    assert approx(converted) == 28316.85
+
+
+def testUnitDatabaseGetUnitNameLegacy(unit_database_posc):
+    assert (
+        unit_database_posc.GetUnitName(
+            quantity_type="volume flow rate", unit="M(ft3)/d"
+        )
+        == "million cubic feet per day"
+    )
+
+
+def testUnitDatabaseCheckQuantityTypeUnitLegacy(unit_database_posc):
+    from barril.units.unit_database import InvalidUnitError
+
+    with raises(
+        InvalidUnitError, match="Invalid unit for quantity_type volume flow rate"
+    ):
+        unit_database_posc.CheckQuantityTypeUnit(
+            quantity_type="volume flow rate", unit="M(ft3)/d"
+        )
+
+
+def testUnitDatabaseGetDefaultCategory(unit_database_posc):
+    category = unit_database_posc.GetDefaultCategory("1000ft3/d")
+    assert category == "volume flow rate"
+
+    class SomeNonExpectedObject:
+        pass
+
+    category = unit_database_posc.GetDefaultCategory(SomeNonExpectedObject())
+    assert category is None

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -686,7 +686,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume",
         "thousand cubic feet",
-        "1000ft3",
+        "Mcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -696,27 +696,17 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "dimensionless",
         "thousand cubic feet per barrel",
-        "1000ft3/bbl",
+        "Mcf/bbl",
         f_base_to_unit,
         f_unit_to_base,
         default_category="volume per volume",
-    )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 28.31685, 86400, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 28.31685, 86400, 0.0)
-    db.AddUnit(
-        "volume flow rate",
-        "thousand cubic feet per day",
-        "1000ft3/d",
-        f_base_to_unit,
-        f_unit_to_base,
-        default_category=None,
     )
     f_unit_to_base = MakeCustomaryToBase(0.0, 92.90304, 86400, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 92.90304, 86400, 0.0)
     db.AddUnit(
         "volume per time per length",
         "thousand cubic feet per day per foot",
-        "1000ft3/d.ft",
+        "Mcf/d.ft",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -726,7 +716,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "productivity index",
         "thousand cubic feet per day per psi",
-        "1000ft3/psi.d",
+        "Mcf/psi.d",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -736,7 +726,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume flow rate",
         "thousand cubic metres per day",
-        "1000m3/d",
+        "Mm3/d",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -746,7 +736,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume per time per length",
         "thousand cubic meter per day per meter",
-        "1000m3/d.m",
+        "Mm3/d.m",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -756,7 +746,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume flow rate",
         "thousand cubic metres per hour",
-        "1000m3/h",
+        "Mm3/h",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -766,7 +756,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume per time per length",
         "thousand cubic meters per hour per meter",
-        "1000m3/h.m",
+        "Mm3/h.m",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -996,6 +986,16 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "pressure", "bar", "bar", f_base_to_unit, f_unit_to_base, default_category=None
     )
+    f_unit_to_base = MakeCustomaryToBase(101325.0, 100000.0, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(101325.0, 100000.0, 1.0, 0.0)
+    db.AddUnit(
+        "pressure",
+        "bar gauge",
+        "bar(g)",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 100000, 3600, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 100000, 3600, 0.0)
     db.AddUnit(
@@ -1211,16 +1211,6 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         f_unit_to_base,
         default_category="volume per length",
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 0.1589873, 28.31685, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 0.1589873, 28.31685, 0.0)
-    db.AddUnit(
-        "dimensionless",
-        "barrel per thousand cubic feet",
-        "bbl/k(ft3)",
-        f_base_to_unit,
-        f_unit_to_base,
-        default_category="volume per volume",
-    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 0.1589873, 86400000, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 0.1589873, 86400000, 0.0)
     db.AddUnit(
@@ -1236,7 +1226,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "dimensionless",
         "barrel per million cubic feet",
-        "bbl/M(ft3)",
+        "bbl/MMcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category="volume per volume",
@@ -2341,7 +2331,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "time per volume",
         "day per thousand cubic feet",
-        "d/k(ft3)",
+        "d/Mcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -6941,7 +6931,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume",
         "million cubic feet",
-        "M(ft3)",
+        "MMcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -6951,7 +6941,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "dimensionless",
         "million cubic feet per acre-foot",
-        "M(ft3)/acre.ft",
+        "MMcf/acre.ft",
         f_base_to_unit,
         f_unit_to_base,
         default_category="volume per volume",
@@ -6961,7 +6951,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume flow rate",
         "million cubic feet per day",
-        "M(ft3)/d",
+        "MMcf/d",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -6971,7 +6961,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume",
         "million cubic meters",
-        "M(m3)",
+        "MMm3",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -6981,7 +6971,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume flow rate",
         "million cubic metres per day",
-        "M(m3)/d",
+        "MMm3/d",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -7597,16 +7587,6 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         "electric polarization",
         "millicoulombs/square metre",
         "mC/m2",
-        f_base_to_unit,
-        f_unit_to_base,
-        default_category=None,
-    )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 28.316846592, 1.0, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 28.316846592, 1.0, 0.0)
-    db.AddUnit(
-        "volume",
-        "thousand cubic feet",
-        "Mcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -8441,16 +8421,6 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         f_unit_to_base,
         default_category="volume per volume",
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 28316.85, 1.0, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 28316.85, 1.0, 0.0)
-    db.AddUnit(
-        "volume",
-        "million cubic feet",
-        "MMcf",
-        f_base_to_unit,
-        f_unit_to_base,
-        default_category=None,
-    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 133.3224, 1.0, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 133.3224, 1.0, 0.0)
     db.AddUnit(
@@ -9117,6 +9087,36 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         "standard volume per time",
         "thousand std cubic metres, 15 degC/day",
         "Mscm(15C)/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "std cubic metres/day",
+        "sm3/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1000, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1000, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "thousand std cubic metres/day",
+        "Msm3/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1000000, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1000000, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "million std cubic metres/day",
+        "MMsm3/d",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -11690,7 +11690,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "dimensionless",
         "cubic meter per million cubic feet",
-        "m3/M(ft3)",
+        "m3/MMcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category="volume per volume",
@@ -11700,7 +11700,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "dimensionless",
         "million cubic feet per barrel",
-        "M(ft3)/bbl",
+        "MMcf/bbl",
         f_base_to_unit,
         f_unit_to_base,
         default_category="volume per volume",
@@ -11815,12 +11815,52 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         f_unit_to_base,
         default_category=None,
     )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 158.9873, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 158.9873, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "thousand stock tank barrels, 60 deg F/day",
+        "Mstb/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 158987.3, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 158987.3, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "million stock tank barrels, 60 deg F/day",
+        "MMstb/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 0.028262357, 86400, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 0.028262357, 86400, 0.0)
     db.AddUnit(
         "standard volume per time",
         "standard cubic feet/day",
         "scf/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 28.262357, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 28.262357, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "thousand standard cubic feet/day",
+        "Mscf/d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 28262.357, 86400, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 28262.357, 86400, 0.0)
+    db.AddUnit(
+        "standard volume per time",
+        "million standard cubic feet/day",
+        "MMscf/d",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -11855,32 +11895,12 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 28.316846592, 0.1589873, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 28.316846592, 0.1589873, 0.0)
-    db.AddUnit(
-        "dimensionless",
-        "thousand cubic feet per barrel",
-        "Mcf/bbl",
-        f_base_to_unit,
-        f_unit_to_base,
-        default_category="volume per volume",
-    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 0.1589873, 28.31685, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 0.1589873, 28.31685, 0.0)
     db.AddUnit(
         "dimensionless",
         "barrel per thousand cubic feet",
         "bbl/Mcf",
-        f_base_to_unit,
-        f_unit_to_base,
-        default_category="volume per volume",
-    )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 0.1589873, 28316.85, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 0.1589873, 28316.85, 0.0)
-    db.AddUnit(
-        "dimensionless",
-        "barrel per million cubic feet",
-        "bbl/MMcf",
         f_base_to_unit,
         f_unit_to_base,
         default_category="volume per volume",
@@ -12474,7 +12494,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
     db.AddUnit(
         "volume",
         "thousand cubic meters",
-        "1000m3",
+        "Mm3",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -13840,12 +13860,12 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
             "dimensionless",
             override=override_categories,
             valid_units=[
-                "1000ft3/bbl",
+                "Mcf/bbl",
                 "bbl/100bbl",
                 "bbl/bbl",
                 "bbl/ft3",
-                "bbl/k(ft3)",
-                "bbl/M(ft3)",
+                "bbl/Mcf",
+                "bbl/MMcf",
                 "cm3/cm3",
                 "cm3/m3",
                 "dm3/m3",
@@ -13860,11 +13880,8 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "sm3/sm3",
                 "volpercent",
                 "volppm",
-                "m3/M(ft3)",
-                "M(ft3)/bbl",
-                "Mcf/bbl",
-                "bbl/Mcf",
-                "bbl/MMcf",
+                "m3/MMcf",
+                "MMcf/bbl",
             ],
         )
         db.AddCategory(
@@ -15387,9 +15404,9 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
             "volume per time per length",
             override=override_categories,
             valid_units=[
-                "1000ft3/d.ft",
-                "1000m3/d.m",
-                "1000m3/h.m",
+                "Mcf/d.ft",
+                "Mm3/d.m",
+                "Mm3/h.m",
                 "bbl/d.ft",
                 "galUK/hr.ft",
                 "galUK/hr.in",
@@ -15415,7 +15432,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
             override=override_categories,
             valid_units=[
                 "m3",
-                "1000ft3",
+                "Mcf",
                 "bbl",
                 "bcf",
                 "cm3",
@@ -15428,16 +15445,14 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "hL",
                 "in3",
                 "L",
-                "M(ft3)",
-                "M(m3)",
+                "MMcf",
+                "MMm3",
                 "Mbbl",
-                "Mcf",
                 "mL",
                 "mm3",
                 "MMbbl",
-                "MMcf",
                 "tcf",
-                "1000m3",
+                "Mm3",
                 "um3",
             ],
         )
@@ -15540,7 +15555,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
             override=override_categories,
             valid_units=[
                 "m3/Pa.s",
-                "1000ft3/psi.d",
+                "Mcf/psi.d",
                 "bbl/d.psi",
                 "bbl/kPa.d",
                 "bbl/psi.d",
@@ -15566,9 +15581,9 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
             override=override_categories,
             valid_units=[
                 "m3/s",
-                "1000ft3/d",
-                "1000m3/d",
-                "1000m3/h",
+                "Mcf/d",
+                "Mm3/d",
+                "Mm3/h",
                 "bbl/d",
                 "bbl/hr",
                 "bbl/min",
@@ -15591,13 +15606,12 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "L/h",
                 "L/min",
                 "L/s",
-                "M(ft3)/d",
-                "M(m3)/d",
+                "MMcf/d",
+                "MMm3/d",
                 "m3/d",
                 "m3/h",
                 "m3/min",
                 "Mbbl/d",
-                "Mcf/d",
                 "um3/s",
             ],
         )
@@ -15942,6 +15956,8 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "ubar",
                 "uPa",
                 "upsi",
+                "Pa(g)",
+                "bar(g)",
             ],
         )
         db.AddCategory(
@@ -15984,6 +16000,8 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "ubar",
                 "uPa",
                 "upsi",
+                "Pa(g)",
+                "bar(g)",
             ],
         )
         db.AddCategory(
@@ -16243,7 +16261,7 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "s/m3",
                 "d/bbl",
                 "d/ft3",
-                "d/k(ft3)",
+                "d/Mcf",
                 "d/m3",
                 "h/ft3",
                 "h/m3",
@@ -16293,8 +16311,15 @@ def FillUnitDatabaseWithPosc(db=None, fill_categories=True, override_categories=
                 "scf(60F)/d",
                 "scm(15C)/d",
                 "stb(60F)/d",
-                "stb/d",
+                "MMscf/d",
+                "MMsm3/d",
+                "MMstb/d",
+                "Mscf/d",
+                "Msm3/d",
+                "Mstb/d",
                 "scf/d",
+                "sm3/d",
+                "stb/d",
             ],
         )
         db.AddCategory(


### PR DESCRIPTION
Scalar's that have been created with "1000ft3", "1000m3", "M(ft3)", "M(m3)" or "k(ft3)" will still work but it'll be converted to "Mcf", "Mm3", "MMcf", "MMm3" and "Mcf", respectively.

Fix #28 
EDEN-2013