### PR TITLE
Add all units section on docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Linting
       run: |
         tox -e linting
+    - name: Docs
+      run: |
+        tox -e docs
 
   deploy:
 

--- a/docs/_extension/list_all_units.py
+++ b/docs/_extension/list_all_units.py
@@ -1,4 +1,4 @@
-from barril.units import Scalar
+from barril.units import UnitDatabase
 from docutils import nodes
 from docutils.statemachine import ViewList
 from sphinx.util import nested_parse_with_titles
@@ -8,17 +8,18 @@ from sphinx.util.docutils import SphinxDirective
 class ListAllUnits(SphinxDirective):
     def run(self):
         rst = ViewList()
-        unit_database = Scalar(10, "m").GetUnitDatabase()
+        unit_database = UnitDatabase.GetSingleton()
         source = "fakefile.rst"
 
         # Create the rst content
-        for categories in sorted(unit_database.IterCategories(), key=str.casefold):
-            title = unit_database.GetCategoryInfo(categories).caption
+        for category in sorted(unit_database.IterCategories(), key=str.casefold):
+            title = unit_database.GetCategoryInfo(category).caption.title()
             rst.append(f".. rubric:: {title}", source)
             rst.append(f"", source)
 
-            for unit in unit_database.GetCategoryInfo(categories).valid_units_set:
-                unit = unit_database.unit_to_unit_info[unit].unit
+            for unit in sorted(
+                unit_database.GetCategoryInfo(category).valid_units_set, key=str.casefold
+            ):
                 name = unit_database.unit_to_unit_info[unit].name
                 rst.append(f'- "{unit}" ({name})', source)
 

--- a/docs/_extension/list_all_units.py
+++ b/docs/_extension/list_all_units.py
@@ -1,0 +1,40 @@
+from barril.units import Scalar
+from docutils import nodes
+from docutils.statemachine import ViewList
+from sphinx.util import nested_parse_with_titles
+from sphinx.util.docutils import SphinxDirective
+
+
+class ListAllUnits(SphinxDirective):
+    def run(self):
+        rst = ViewList()
+        unit_database = Scalar(10, "m").GetUnitDatabase()
+        source = "fakefile.rst"
+
+        # Create the rst content
+        for categories in sorted(unit_database.IterCategories(), key=str.casefold):
+            title = unit_database.GetCategoryInfo(categories).caption
+            rst.append(f".. rubric:: {title}", source)
+            rst.append(f"", source)
+
+            for unit in unit_database.GetCategoryInfo(categories).valid_units_set:
+                unit = unit_database.unit_to_unit_info[unit].unit
+                name = unit_database.unit_to_unit_info[unit].name
+                rst.append(f'- "{unit}" ({name})', source)
+
+            rst.append(f" ", source)
+
+        # Create a node.
+        node = nodes.section()
+        node.document = self.state.document
+
+        # Parse the rst.
+        nested_parse_with_titles(self.state, rst, node)
+
+        # And return the result.
+        return node.children
+
+
+def setup(app):
+    app.add_directive("list_all_units", ListAllUnits)
+    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/_extension/list_all_units.py
+++ b/docs/_extension/list_all_units.py
@@ -21,7 +21,7 @@ class ListAllUnits(SphinxDirective):
                 unit_database.GetCategoryInfo(category).valid_units_set, key=str.casefold
             ):
                 name = unit_database.unit_to_unit_info[unit].name
-                rst.append(f'- "{unit}" ({name})', source)
+                rst.append(f'- ``"{unit}"`` ({name})', source)
 
             rst.append(f" ", source)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
-
+sys.path.append(os.path.abspath("./_extension"))
 
 # -- General configuration ---------------------------------------------
 
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "list_all_units"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -48,7 +48,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Barril"
-copyright = "2018, ESSS"
+copyright = "2019, ESSS"
 author = "ESSS"
 
 # The version info for the project you're documenting, acts as replacement

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to Barril's documentation!
    readme
    installation
    usage
+   units
    api
    contributing
    changelog

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -1,4 +1,4 @@
-List of physical units
+List of Physical Units
 ======================
 
 .. list_all_units::

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -1,0 +1,4 @@
+List of physical units
+======================
+
+.. list_all_units::


### PR DESCRIPTION
Link for the docs

https://barril.readthedocs.io/en/add-all-units/

The section `List of physical units` was added,

![image](https://user-images.githubusercontent.com/5083518/67417666-ae09e500-f59f-11e9-9177-9e1439ad9d29.png)


CC @tadeu @arthursoprana @igortg @tigarmo @GabrielMarcilio 