### PR TITLE
Add new unit for productivity index category [m3/d/kgf/cm2]

### DIFF
--- a/src/barril/units/_tests/test_posc.py
+++ b/src/barril/units/_tests/test_posc.py
@@ -482,6 +482,7 @@ def testProductivityIndex() -> None:
     assert default.GetValue("m3/kPa.d") == approx(86400000.0)
     assert default.GetValue("m3/kPa.h") == approx(3600000.0)
     assert default.GetValue("m3/psi.d") == approx(595707004.8)
+    assert default.GetValue("m3/d/kgf/cm2") == approx(8472945600.38827)
 
 
 def testThermalConductivity() -> None:

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -6553,6 +6553,16 @@ def FillUnitDatabaseWithPosc(
         f_unit_to_base,
         default_category=None,
     )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1.1802270983e-10, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1.1802270983e-10, 1.0, 0.0)
+    db.AddUnit(
+        "productivity index",
+        "cubic meter per day per kilogram-force per square centimeter",
+        "m3/d/kgf/cm2",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 1, 86400, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 1, 86400, 0.0)
     db.AddUnit(
@@ -14322,6 +14332,7 @@ def FillUnitDatabaseWithPosc(
                 "m3/kPa.d",
                 "m3/kPa.h",
                 "m3/psi.d",
+                "m3/d/kgf/cm2",
             ],
         )
         db.AddCategory(


### PR DESCRIPTION
The new unit was added as a "productivity index" and it is the same as the unit "injectivity factor in meter per day" configured as an "injectivity factor".

The format used is `m3/d/kgf/cm2` in contrast with `(m3/d)/(kgf/cm2)` to maintain the coherence between "productivity index" units.