### PR TITLE
Add other units for mole per mass quantity and define a molality category

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+1.16.0 (2023-04-26)
+-------------------
+
+* Add more units for ``mole per mass`` quantity.
+* Define a ``molality`` category.
+
 1.15.0 (2023-04-03)
 -------------------
 

--- a/src/barril/units/_tests/test_posc_additional_units.py
+++ b/src/barril/units/_tests/test_posc_additional_units.py
@@ -174,6 +174,15 @@ def testMassPerMol(db) -> None:
     assert kgpermol_to_gpermol == 1000
     assert db.Convert("mass per mol", "g/mol", "lb/lbmole", 1) == 1
 
+@pytest.mark.parametrize('category', ['mole per mass', 'molality'])
+def testMolPerMass(db, category) -> None:
+    molperg_to_molperkg = db.Convert(category, "mol/g", "mol/kg", 1.0)
+    molperkg_to_molperg = db.Convert(category, "mol/kg", "mol/g", 1.0)
+
+    assert molperg_to_molperkg == 1000
+    assert molperkg_to_molperg == 0.001
+    assert db.Convert(category, "mol/g", "lbmole/lb", 1) == 1
+
 
 def testInjectivityFactor(db) -> None:
     quantity_type = db.GetCategoryInfo("injectivity factor").quantity_type

--- a/src/barril/units/_tests/test_posc_additional_units.py
+++ b/src/barril/units/_tests/test_posc_additional_units.py
@@ -174,7 +174,8 @@ def testMassPerMol(db) -> None:
     assert kgpermol_to_gpermol == 1000
     assert db.Convert("mass per mol", "g/mol", "lb/lbmole", 1) == 1
 
-@pytest.mark.parametrize('category', ['mole per mass', 'molality'])
+
+@pytest.mark.parametrize("category", ["mole per mass", "molality"])
 def testMolPerMass(db, category) -> None:
     molperg_to_molperkg = db.Convert(category, "mol/g", "mol/kg", 1.0)
     molperkg_to_molperg = db.Convert(category, "mol/kg", "mol/g", 1.0)

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -11155,6 +11155,21 @@ def FillUnitDatabaseWithPosc(
         f_unit_to_base,
         default_category=None,
     )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1000.0, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1000.0, 1.0, 0.0)
+    db.AddUnit(
+        "mole per mass", "mol/g", "mol/g", f_base_to_unit, f_unit_to_base, default_category=None
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 1000.0, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 1000.0, 1.0, 0.0)
+    db.AddUnit(
+        "mole per mass",
+        "lbmole/lb",
+        "lbmole/lb",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 0.07211, 1.0, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 0.07211, 1.0, 0.0)
     db.AddUnit(
@@ -12336,6 +12351,13 @@ def FillUnitDatabaseWithPosc(
         )
         db.AddCategory(
             "mole per mass",
+            "mole per mass",
+            override=override_categories,
+            valid_units=["mol/kg"],
+            default_unit="mol/kg",
+        )
+        db.AddCategory(
+            "molality",
             "mole per mass",
             override=override_categories,
             valid_units=["mol/kg"],


### PR DESCRIPTION
Add other units for mole per mass quantity, namely `lbmol/lb` and `mol/g`.
A new category called `molality`  was also introduced.