### PR TITLE
Include the required units of the Forchheimer IPR model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,19 @@
+1.18.0 (2023-06-01)
+-------------------
+
+* Define the categories ``forchheimer linear productivity index`` and ``forchheimer linear productivity index``.
+* Define the quantity types ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
+* Add ``square pascal second/standard cubic metres`` (``Pa2.s/scm``) unit to ``forchheimer linear productivity index`` category.
+* Add ``square pascal day/standard cubic metres`` (``Pa2.d/scm``) unit to ``forchheimer linear productivity index`` category.
+* Add ``square psi day per standard cubic feet`` (``psi2.d/scf``) unit to ``forchheimer linear productivity index`` category.
+* Add ``square psi day per thousand standard cubic feet`` (``psi2.d/Mscf``) unit to ``forchheimer linear productivity index`` category.
+* Add ``square bar day per standard cubic metres`` (``bar2.d/scm``) unit to ``forchheimer linear productivity index`` category.
+* Add ``square pascal square second/square standard cubic metres`` (``Pa2.s2/scm2``) unit to ``forchheimer quadratic productivity index`` category.
+* Add ``square pascal square day/square standard cubic metres`` (``Pa2.d2/scm2``) unit to ``forchheimer quadratic productivity index`` category.
+* Add ``square psi square day per square standard cubic feet`` (``psi2.d2/scf2``) unit to ``forchheimer quadratic productivity index`` category.
+* Add ``square psi square day per thousand square standard cubic feet`` (``psi2.d2/Mscf2``) unit to ``forchheimer quadratic productivity index`` category.
+* Add ``square bar square day per square standard cubic metres`` (``bar2.d2/scm2``) unit to ``forchheimer quadratic productivity index`` category.
+
 1.17.0 (2023-05-02)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,16 +3,7 @@
 
 * Define the categories ``forchheimer linear productivity index`` and ``forchheimer linear productivity index``.
 * Define the quantity types ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
-* Add ``square pascal second/standard cubic metres`` (``Pa2.s/scm``) unit to ``forchheimer linear productivity index`` category.
-* Add ``square pascal day/standard cubic metres`` (``Pa2.d/scm``) unit to ``forchheimer linear productivity index`` category.
-* Add ``square psi day per standard cubic feet`` (``psi2.d/scf``) unit to ``forchheimer linear productivity index`` category.
-* Add ``square psi day per thousand standard cubic feet`` (``psi2.d/Mscf``) unit to ``forchheimer linear productivity index`` category.
-* Add ``square bar day per standard cubic metres`` (``bar2.d/scm``) unit to ``forchheimer linear productivity index`` category.
-* Add ``square pascal square second/square standard cubic metres`` (``Pa2.s2/scm2``) unit to ``forchheimer quadratic productivity index`` category.
-* Add ``square pascal square day/square standard cubic metres`` (``Pa2.d2/scm2``) unit to ``forchheimer quadratic productivity index`` category.
-* Add ``square psi square day per square standard cubic feet`` (``psi2.d2/scf2``) unit to ``forchheimer quadratic productivity index`` category.
-* Add ``square psi square day per thousand square standard cubic feet`` (``psi2.d2/Mscf2``) unit to ``forchheimer quadratic productivity index`` category.
-* Add ``square bar square day per square standard cubic metres`` (``bar2.d2/scm2``) unit to ``forchheimer quadratic productivity index`` category.
+* Add units to categories ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
 
 1.17.0 (2023-05-02)
 -------------------

--- a/src/barril/units/_tests/test_posc.py
+++ b/src/barril/units/_tests/test_posc.py
@@ -488,6 +488,7 @@ def testProductivityIndex() -> None:
 def testForchheimerLinearCoefficient() -> None:
     default = units.Scalar("forchheimer linear productivity index", 1, "Pa2.s/scm")
     assert default.value == 1.0
+    assert default.GetValue("Pa2.d/scm") == approx(1.1574074074074073e-05)
     assert default.GetValue("psi2.d/scf") == approx(6.89434766020926e-15)
     assert default.GetValue("psi2.d/Mscf") == approx(6.89434766020926e-12)
     assert default.GetValue("bar2.d/scm") == approx(1.1574074074074073e-15)
@@ -496,6 +497,7 @@ def testForchheimerLinearCoefficient() -> None:
 def testForchheimerQuadraticCoefficient() -> None:
     default = units.Scalar("forchheimer quadratic productivity index", 1, "Pa2.s2/scm2")
     assert default.value == 1.0
+    assert default.GetValue("Pa2.d2/scm2") == approx(1.3395919067215364e-10)
     assert default.GetValue("psi2.d2/scf2") == approx(2.259562326921988e-21)
     assert default.GetValue("psi2.d2/Mscf2") == approx(2.259562326921988e-19)
     assert default.GetValue("bar2.d2/scm2") == approx(1.3395919067215364e-20)

--- a/src/barril/units/_tests/test_posc.py
+++ b/src/barril/units/_tests/test_posc.py
@@ -486,19 +486,19 @@ def testProductivityIndex() -> None:
 
 
 def testForchheimerLinearCoefficient() -> None:
-    default = units.Scalar("forchheimer linear productivity index", 1, "Pa2/scm.s")
+    default = units.Scalar("forchheimer linear productivity index", 1, "Pa2.s/scm")
     assert default.value == 1.0
-    assert default.GetValue("psi2/scf.d") == approx(5.146602950955572e-05)
-    assert default.GetValue("psi2/Mscf.d") == approx(5.146602950955572e-02)
-    assert default.GetValue("bar2/scm.d") == approx(8.64e-06)
+    assert default.GetValue("psi2.d/scf") == approx(6.89434766020926e-15)
+    assert default.GetValue("psi2.d/Mscf") == approx(6.89434766020926e-12)
+    assert default.GetValue("bar2.d/scm") == approx(1.1574074074074073e-15)
 
 
 def testForchheimerQuadraticCoefficient() -> None:
-    default = units.Scalar("forchheimer quadratic productivity index", 1, "Pa2/scm2.s2")
+    default = units.Scalar("forchheimer quadratic productivity index", 1, "Pa2.s2/scm2")
     assert default.value == 1.0
-    assert default.GetValue("psi2/scf2.d2") == approx(0.12591552922457175)
-    assert default.GetValue("psi2/Mscf2.d2") == approx(125.91552922457175)
-    assert default.GetValue("bar2/scm2.d2") == approx(0.746496)
+    assert default.GetValue("psi2.d2/scf2") == approx(2.259562326921988e-21)
+    assert default.GetValue("psi2.d2/Mscf2") == approx(2.259562326921988e-19)
+    assert default.GetValue("bar2.d2/scm2") == approx(1.3395919067215364e-20)
 
 
 def testThermalConductivity() -> None:

--- a/src/barril/units/_tests/test_posc.py
+++ b/src/barril/units/_tests/test_posc.py
@@ -485,6 +485,22 @@ def testProductivityIndex() -> None:
     assert default.GetValue("m3/d/kgf/cm2") == approx(8472945600.38827)
 
 
+def testForchheimerLinearCoefficient() -> None:
+    default = units.Scalar("forchheimer linear productivity index", 1, "Pa2/scm.s")
+    assert default.value == 1.0
+    assert default.GetValue("psi2/scf.d") == approx(5.146602950955572e-05)
+    assert default.GetValue("psi2/Mscf.d") == approx(5.146602950955572e-02)
+    assert default.GetValue("bar2/scm.d") == approx(8.64e-06)
+
+
+def testForchheimerQuadraticCoefficient() -> None:
+    default = units.Scalar("forchheimer quadratic productivity index", 1, "Pa2/scm2.s2")
+    assert default.value == 1.0
+    assert default.GetValue("psi2/scf2.d2") == approx(0.12591552922457175)
+    assert default.GetValue("psi2/Mscf2.d2") == approx(125.91552922457175)
+    assert default.GetValue("bar2/scm2.d2") == approx(0.746496)
+
+
 def testThermalConductivity() -> None:
     default = units.Scalar("thermal conductivity", 1, "W/m.K")
     assert default.GetValue("Btu/hr.ft.degF") == approx(0.5777892051642799)

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -165,13 +165,13 @@ def FillUnitDatabaseWithPosc(
     db.AddUnitBase("productivity index", "cubic metres/second pascal", "m3/Pa.s")
     db.AddUnitBase(
         "forchheimer linear productivity index",
-        "square pascal/standard cubic metres per second",
-        "Pa2/scm.s",
+        "square pascal second/standard cubic metres",
+        "Pa2.s/scm",
     )
     db.AddUnitBase(
         "forchheimer quadratic productivity index",
-        "square pascal/square standard cubic metres per square second",
-        "Pa2/scm2.s2",
+        "square pascal square second/square standard cubic metres",
+        "Pa2.s2/scm2",
     )
     db.AddUnitBase("specific productivity index", "cubic metres/pascal second squared", "m3/Pa2.s2")
     db.AddUnitBase("volume flow rate", "cubic metres/second", "m3/s")
@@ -1096,62 +1096,70 @@ def FillUnitDatabaseWithPosc(
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 2446.5755455488, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 2446.5755455488, 0.0)
+    f_unit_to_base = MakeCustomaryToBase(0.0, 4107255390590.574957095427052896, 0.028316846592, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 4107255390590.574957095427052896, 0.028316846592, 0.0)
     db.AddUnit(
         "forchheimer linear productivity index",
-        "square psi per standard cubic feet per day",
-        "psi2/scf.d",
+        "square psi day per standard cubic feet",
+        "psi2.d/scf",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 2446575.5455488, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 2446575.5455488, 0.0)
+    f_unit_to_base = MakeCustomaryToBase(0.0, 4107255390590.574957095427052896, 28.316846592, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 4107255390590.574957095427052896, 28.316846592, 0.0)
     db.AddUnit(
         "forchheimer linear productivity index",
-        "square psi per thousand standard cubic feet per day",
-        "psi2/Mscf.d",
+        "square psi day per thousand standard cubic feet",
+        "psi2.d/Mscf",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 10000000000.0, 86400.0, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 10000000000.0, 86400.0, 0.0)
+    f_unit_to_base = MakeCustomaryToBase(0.0, 8.64e14, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 8.64e14, 1.0, 0.0)
     db.AddUnit(
         "forchheimer linear productivity index",
-        "square bar per standard cubic metres per day",
-        "bar2/scm.d",
+        "square bar day per standard cubic metres",
+        "bar2.d/scm",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 5985731.90007740, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 5985731.90007740, 0.0)
+    f_unit_to_base = MakeCustomaryToBase(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-04, 0.0
+    )
+    f_base_to_unit = MakeBaseToCustomary(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-04, 0.0
+    )
     db.AddUnit(
         "forchheimer quadratic productivity index",
-        "square psi per square standard cubic feet per square day",
-        "psi2/scf2.d2",
+        "square psi square day per square standard cubic feet",
+        "psi2.d2/scf2",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 5985731900.07740, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 5985731900.07740, 0.0)
+    f_unit_to_base = MakeCustomaryToBase(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-01, 0.0
+    )
+    f_base_to_unit = MakeBaseToCustomary(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-01, 0.0
+    )
     db.AddUnit(
         "forchheimer quadratic productivity index",
-        "square psi per thousand square standard cubic feet per square day",
-        "psi2/Mscf2.d2",
+        "square psi square day per thousand square standard cubic feet",
+        "psi2.d2/Mscf2",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
     )
-    f_unit_to_base = MakeCustomaryToBase(0.0, 10000000000.0, 7464960000.0, 0.0)
-    f_base_to_unit = MakeBaseToCustomary(0.0, 10000000000.0, 7464960000.0, 0.0)
+    f_unit_to_base = MakeCustomaryToBase(0.0, 7.46496e19, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 7.46496e19, 1.0, 0.0)
     db.AddUnit(
         "forchheimer quadratic productivity index",
-        "square bar per square standard cubic metres per square day",
-        "bar2/scm2.d2",
+        "square bar square day per square standard cubic metres",
+        "bar2.d2/scm2",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -14437,13 +14445,13 @@ def FillUnitDatabaseWithPosc(
             "forchheimer linear productivity index",
             "forchheimer linear productivity index",
             override=override_categories,
-            valid_units=["Pa2/scm.s", "psi2/scf.d", "psi2/Mscf.d", "bar2/scm.d"],
+            valid_units=["Pa2.s/scm", "psi2.d/scf", "psi2.d/Mscf", "bar2.d/scm"],
         )
         db.AddCategory(
             "forchheimer quadratic productivity index",
             "forchheimer quadratic productivity index",
             override=override_categories,
-            valid_units=["Pa2/scm2.s2", "psi2/scf2.d2", "psi2/Mscf2.d2", "bar2/scm2.d2"],
+            valid_units=["Pa2.s2/scm2", "psi2.d2/scf2", "psi2.d2/Mscf2", "bar2.d2/scm2"],
         )
         db.AddCategory(
             "volume flow rate",

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -1096,6 +1096,16 @@ def FillUnitDatabaseWithPosc(
         f_unit_to_base,
         default_category=None,
     )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 8.64e4, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 8.64e4, 1.0, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square pascal day per standard cubic metres",
+        "Pa2.d/scm",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
     f_unit_to_base = MakeCustomaryToBase(0.0, 4107255390590.574957095427052896, 0.028316846592, 0.0)
     f_base_to_unit = MakeBaseToCustomary(0.0, 4107255390590.574957095427052896, 0.028316846592, 0.0)
     db.AddUnit(
@@ -1122,6 +1132,16 @@ def FillUnitDatabaseWithPosc(
         "forchheimer linear productivity index",
         "square bar day per standard cubic metres",
         "bar2.d/scm",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 7.46496e9, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 7.46496e9, 1.0, 0.0)
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square pascal square day per standard cubic metres",
+        "Pa2.d2/scm2",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -14445,13 +14465,19 @@ def FillUnitDatabaseWithPosc(
             "forchheimer linear productivity index",
             "forchheimer linear productivity index",
             override=override_categories,
-            valid_units=["Pa2.s/scm", "psi2.d/scf", "psi2.d/Mscf", "bar2.d/scm"],
+            valid_units=["Pa2.s/scm", "Pa2.d/scm", "psi2.d/scf", "psi2.d/Mscf", "bar2.d/scm"],
         )
         db.AddCategory(
             "forchheimer quadratic productivity index",
             "forchheimer quadratic productivity index",
             override=override_categories,
-            valid_units=["Pa2.s2/scm2", "psi2.d2/scf2", "psi2.d2/Mscf2", "bar2.d2/scm2"],
+            valid_units=[
+                "Pa2.s2/scm2",
+                "Pa2.d2/scm2",
+                "psi2.d2/scf2",
+                "psi2.d2/Mscf2",
+                "bar2.d2/scm2",
+            ],
         )
         db.AddCategory(
             "volume flow rate",

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -163,6 +163,16 @@ def FillUnitDatabaseWithPosc(
     db.AddUnitBase("specific volume", "cubic metres/kilogram", "m3/kg")
     db.AddUnitBase("molar volume", "cubic metres/mole", "m3/mol")
     db.AddUnitBase("productivity index", "cubic metres/second pascal", "m3/Pa.s")
+    db.AddUnitBase(
+        "forchheimer linear productivity index",
+        "square pascal/standard cubic metres per second",
+        "Pa2/scm.s",
+    )
+    db.AddUnitBase(
+        "forchheimer quadratic productivity index",
+        "square pascal/square standard cubic metres per square second",
+        "Pa2/scm2.s2",
+    )
     db.AddUnitBase("specific productivity index", "cubic metres/pascal second squared", "m3/Pa2.s2")
     db.AddUnitBase("volume flow rate", "cubic metres/second", "m3/s")
     db.AddUnitBase("volume per time per time", "cubic metres/seconds squared", "m3/s2")
@@ -1082,6 +1092,66 @@ def FillUnitDatabaseWithPosc(
         "productivity index",
         "barrel per day per kilopascal",
         "bbl/kPa.d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 2446.5755455488, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 2446.5755455488, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square psi per standard cubic feet per day",
+        "psi2/scf.d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 2446575.5455488, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 2446575.5455488, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square psi per thousand standard cubic feet per day",
+        "psi2/Mscf.d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 10000000000.0, 86400.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 10000000000.0, 86400.0, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square bar per standard cubic metres per day",
+        "bar2/scm.d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 5985731.90007740, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 5985731.90007740, 0.0)
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square psi per square standard cubic feet per square day",
+        "psi2/scf2.d2",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 47537678.13183536, 5985731900.07740, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 47537678.13183536, 5985731900.07740, 0.0)
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square psi per thousand square standard cubic feet per square day",
+        "psi2/Mscf2.d2",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 10000000000.0, 7464960000.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 10000000000.0, 7464960000.0, 0.0)
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square bar per square standard cubic metres per square day",
+        "bar2/scm2.d2",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -14362,6 +14432,18 @@ def FillUnitDatabaseWithPosc(
             "specific productivity index",
             override=override_categories,
             valid_units=["m3/Pa2.s2", "bbl/cP.d.psi", "m3/cP.d.kPa", "m3/cP.Pa.s"],
+        ),
+        db.AddCategory(
+            "forchheimer linear productivity index",
+            "forchheimer linear productivity index",
+            override=override_categories,
+            valid_units=["Pa2/scm.s", "psi2/scf.d", "psi2/Mscf.d", "bar2/scm.d"],
+        )
+        db.AddCategory(
+            "forchheimer quadratic productivity index",
+            "forchheimer quadratic productivity index",
+            override=override_categories,
+            valid_units=["Pa2/scm2.s2", "psi2/scf2.d2", "psi2/Mscf2.d2", "bar2/scm2.d2"],
         )
         db.AddCategory(
             "volume flow rate",


### PR DESCRIPTION
ASIM-5275

Adds specific units employed in the Forchheimer IPR model. A new category and quantity type is defined for linear and quadratic parameters. 