### PR TITLE
Include the required units of the Forchheimer IPR model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+1.18.0 (2023-06-01)
+-------------------
+
+* Define the categories ``forchheimer linear productivity index`` and ``forchheimer linear productivity index``.
+* Define the quantity types ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
+* Add units to categories ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
+
 1.17.0 (2023-05-02)
 -------------------
 

--- a/src/barril/units/_tests/test_posc.py
+++ b/src/barril/units/_tests/test_posc.py
@@ -485,6 +485,24 @@ def testProductivityIndex() -> None:
     assert default.GetValue("m3/d/kgf/cm2") == approx(8472945600.38827)
 
 
+def testForchheimerLinearCoefficient() -> None:
+    default = units.Scalar("forchheimer linear productivity index", 1, "Pa2.s/scm")
+    assert default.value == 1.0
+    assert default.GetValue("Pa2.d/scm") == approx(1.1574074074074073e-05)
+    assert default.GetValue("psi2.d/scf") == approx(6.89434766020926e-15)
+    assert default.GetValue("psi2.d/Mscf") == approx(6.89434766020926e-12)
+    assert default.GetValue("bar2.d/scm") == approx(1.1574074074074073e-15)
+
+
+def testForchheimerQuadraticCoefficient() -> None:
+    default = units.Scalar("forchheimer quadratic productivity index", 1, "Pa2.s2/scm2")
+    assert default.value == 1.0
+    assert default.GetValue("Pa2.d2/scm2") == approx(1.3395919067215364e-10)
+    assert default.GetValue("psi2.d2/scf2") == approx(2.259562326921988e-21)
+    assert default.GetValue("psi2.d2/Mscf2") == approx(2.259562326921988e-19)
+    assert default.GetValue("bar2.d2/scm2") == approx(1.3395919067215364e-20)
+
+
 def testThermalConductivity() -> None:
     default = units.Scalar("thermal conductivity", 1, "W/m.K")
     assert default.GetValue("Btu/hr.ft.degF") == approx(0.5777892051642799)

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -163,6 +163,16 @@ def FillUnitDatabaseWithPosc(
     db.AddUnitBase("specific volume", "cubic metres/kilogram", "m3/kg")
     db.AddUnitBase("molar volume", "cubic metres/mole", "m3/mol")
     db.AddUnitBase("productivity index", "cubic metres/second pascal", "m3/Pa.s")
+    db.AddUnitBase(
+        "forchheimer linear productivity index",
+        "square pascal second/standard cubic metres",
+        "Pa2.s/scm",
+    )
+    db.AddUnitBase(
+        "forchheimer quadratic productivity index",
+        "square pascal square second/square standard cubic metres",
+        "Pa2.s2/scm2",
+    )
     db.AddUnitBase("specific productivity index", "cubic metres/pascal second squared", "m3/Pa2.s2")
     db.AddUnitBase("volume flow rate", "cubic metres/second", "m3/s")
     db.AddUnitBase("volume per time per time", "cubic metres/seconds squared", "m3/s2")
@@ -1082,6 +1092,94 @@ def FillUnitDatabaseWithPosc(
         "productivity index",
         "barrel per day per kilopascal",
         "bbl/kPa.d",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 8.64e4, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 8.64e4, 1.0, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square pascal day per standard cubic metres",
+        "Pa2.d/scm",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 4107255390590.574957095427052896, 0.028316846592, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 4107255390590.574957095427052896, 0.028316846592, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square psi day per standard cubic feet",
+        "psi2.d/scf",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 4107255390590.574957095427052896, 28.316846592, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 4107255390590.574957095427052896, 28.316846592, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square psi day per thousand standard cubic feet",
+        "psi2.d/Mscf",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 8.64e14, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 8.64e14, 1.0, 0.0)
+    db.AddUnit(
+        "forchheimer linear productivity index",
+        "square bar day per standard cubic metres",
+        "bar2.d/scm",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 7.46496e9, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 7.46496e9, 1.0, 0.0)
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square pascal square day per standard cubic metres",
+        "Pa2.d2/scm2",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-04, 0.0
+    )
+    f_base_to_unit = MakeBaseToCustomary(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-04, 0.0
+    )
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square psi square day per square standard cubic feet",
+        "psi2.d2/scf2",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-01, 0.0
+    )
+    f_base_to_unit = MakeBaseToCustomary(
+        0.0, 354866865747025676.29304489737021, 8.01843800914862014464e-01, 0.0
+    )
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square psi square day per thousand square standard cubic feet",
+        "psi2.d2/Mscf2",
+        f_base_to_unit,
+        f_unit_to_base,
+        default_category=None,
+    )
+    f_unit_to_base = MakeCustomaryToBase(0.0, 7.46496e19, 1.0, 0.0)
+    f_base_to_unit = MakeBaseToCustomary(0.0, 7.46496e19, 1.0, 0.0)
+    db.AddUnit(
+        "forchheimer quadratic productivity index",
+        "square bar square day per square standard cubic metres",
+        "bar2.d2/scm2",
         f_base_to_unit,
         f_unit_to_base,
         default_category=None,
@@ -14362,6 +14460,24 @@ def FillUnitDatabaseWithPosc(
             "specific productivity index",
             override=override_categories,
             valid_units=["m3/Pa2.s2", "bbl/cP.d.psi", "m3/cP.d.kPa", "m3/cP.Pa.s"],
+        ),
+        db.AddCategory(
+            "forchheimer linear productivity index",
+            "forchheimer linear productivity index",
+            override=override_categories,
+            valid_units=["Pa2.s/scm", "Pa2.d/scm", "psi2.d/scf", "psi2.d/Mscf", "bar2.d/scm"],
+        )
+        db.AddCategory(
+            "forchheimer quadratic productivity index",
+            "forchheimer quadratic productivity index",
+            override=override_categories,
+            valid_units=[
+                "Pa2.s2/scm2",
+                "Pa2.d2/scm2",
+                "psi2.d2/scf2",
+                "psi2.d2/Mscf2",
+                "bar2.d2/scm2",
+            ],
         )
         db.AddCategory(
             "volume flow rate",


### PR DESCRIPTION
ASIM-5275

Adds specific units employed in the Forchheimer IPR model. A new category and quantity type is defined for linear and quadratic parameters.