### PR TITLE
Add units for the mass density derivative with respect to enthalpy 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,13 @@
+1.19.0 (2023-08-10)
+-------------------
+
+* Define the category and quantity type ``density derivative in respect to enthalpy``(default unit: ``kg2/m3.J``).
+
 1.18.0 (2023-06-01)
 -------------------
 
-* Define the categories ``forchheimer linear productivity index`` and ``forchheimer linear productivity index``.
-* Define the quantity types ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
+* Define categories ``forchheimer linear productivity index`` and ``forchheimer linear productivity index``.
+* Define quantity types ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
 * Add units to categories ``forchheimer linear productivity index`` and ``forchheimer quadratic productivity index``.
 
 1.17.0 (2023-05-02)

--- a/src/barril/units/_tests/test_posc.py
+++ b/src/barril/units/_tests/test_posc.py
@@ -432,6 +432,12 @@ def testDensityDerivativePerTemperatureUnitConversion() -> None:
     assert density_derivative_per_temperature.GetValue("kg/m3.degC") == 1.0
 
 
+def testDensityDerivativePerEnthalpyUnitConversion() -> None:
+    default = units.Scalar("density derivative in respect to enthalpy", 1, "kg2/m3.J")
+    assert default.value == 1.0
+    assert default.GetValue("kg2/m3.J") == 1.0
+
+
 def testStandardVolumePerStandardVolumeSmoke() -> None:
     standard_per_standard = units.Scalar(
         "standard volume per standard volume", 1, "scm(15C)/scm(15C)"

--- a/src/barril/units/posc.py
+++ b/src/barril/units/posc.py
@@ -298,6 +298,11 @@ def FillUnitDatabaseWithPosc(
         "kilogram per cubic meter degrees Celsius",
         "kg/m3.degC",
     )
+    db.AddUnitBase(
+        "density derivative in respect to enthalpy",
+        "square kilogram per cubic meter Joule",
+        "kg2/m3.J",
+    )
     db.AddUnitBase("computer binary memory", "Byte", "Byte")
     db.AddUnitBase("flow coefficient", "flow rate per pressure power of 0.5 ", "(m3/s)/(Pa^0.5)")
     db.AddUnitBase("temperature per area", "degrees Celsius per square meter", "degC/m2")
@@ -15797,6 +15802,12 @@ def FillUnitDatabaseWithPosc(
             "density derivative in respect to temperature",
             override=override_categories,
             valid_units=["kg/m3.degC", "kg/m3.K"],
+        )
+        db.AddCategory(
+            "density derivative in respect to enthalpy",
+            "density derivative in respect to enthalpy",
+            override=override_categories,
+            valid_units=["kg2/m3.J"],
         )
         db.AddCategory(
             "computer binary memory",


### PR DESCRIPTION
DCC-93

This is an intermediate step toward the conclusion of DCC-93. Flash exported from PVTLib now has new outputs regarding derivatives with respect to enthalpy. This PR aims to cover the units of these derivatives including a new category and quantity type.