### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,3 +31,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
+    - name: GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: dist/*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-2.0.0 (UNRELEASED)
+2.0.0 (2024-02-14)
 ------------------
 
 * Added support for Python 3.11 and 3.12.


### PR DESCRIPTION
Release version 2.0.0

* Added support for Python 3.11 and 3.12.
* Dropped support for EOL Python 3.6 and 3.7.
* Add categorie and quantity type ``henry solubility coefficient``  (``mol/m3.Pa``)
* Add categorie and quantity type ``crystallization kinetic rate`` (``mol/m2.s.Pa``)
